### PR TITLE
Add support for parsing arena matches in event templates

### DIFF
--- a/event_templates/ARENA_MATCH_END.json
+++ b/event_templates/ARENA_MATCH_END.json
@@ -1,0 +1,6 @@
+{
+    "winningTeam": 1,
+    "matchDuration": 2,
+    "newRatingTeam1": 3,
+    "newRatingTeam2": 4
+}

--- a/event_templates/ARENA_MATCH_START.json
+++ b/event_templates/ARENA_MATCH_START.json
@@ -1,0 +1,5 @@
+{
+    "instanceID": 1,
+    "matchType": 3,
+    "teamId": 4
+}


### PR DESCRIPTION
Included all fields except for an unknown one in ARENA_MATCH_START